### PR TITLE
Register port with SELinux for CentOS

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,16 @@
   tags:
     - sshd
 
+- name: Register our custom SSH port "{{ sshd.Port }}" with SELinux
+  become: yes
+  become_method: sudo
+  seport:
+    ports: "{{ sshd.Port }}"
+    proto: tcp
+    setype: ssh_port_t
+    state: present
+  when: ansible_os_family == "RedHat"
+
 - name: Run directory
   file:
     path: /var/run/sshd


### PR DESCRIPTION
Restarting the sshd service may require permission from SELinux for certain ports. To remedy that, I moved the task for SELinux port registration as one of the first tasks here.