### PR TITLE
Renamed sshd default variable

### DIFF
--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -4,7 +4,7 @@ sshd_packages:
   - openssh
   - openssh-server
 sshd_sftp_server: /usr/libexec/openssh/sftp-server
-sshd:
+sshd_defaults:
   SyslogFacility: AUTHPRIV
   PermitRootLogin: forced-commands-only
   AuthorizedKeysFile: .ssh/authorized_keys


### PR DESCRIPTION
Renamed Amazon.yml sshd to sshd_defaults to work in CreateUniverse workflow (yugabyte/yugabyte-db#3572). In the current version, ansible could not resolve the custom ssh Port variable. 