### PR TITLE
Don't register a custom SSH port if SELinux is disabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,11 @@
     proto: tcp
     setype: ssh_port_t
     state: present
-  when: ansible_os_family == "RedHat"
+  # `seport` fails if SELinux is not enabled:
+  # https://github.com/yugabyte/yugabyte-db/issues/7315
+  # `ansible_selinux` can be either a boolean or a dictionary:
+  # https://github.com/ansible/ansible/issues/18692
+  when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
 
 - name: Run directory
   file:


### PR DESCRIPTION
Fixes "SELinux is disabled on this host" error.

See c76e617 "register with SELinuxwq".
Fixes https://github.com/yugabyte/yugabyte-db/issues/7315