### PR TITLE
Update system module input for new ansible version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,7 +75,7 @@
   service:
     name: "{{ sshd_service }}"
     enabled: true
-    state: running
+    state: started
   when: sshd_manage_service
   tags:
     - sshd


### PR DESCRIPTION
For the new ansible version, the `system` module requires `started` instead of `running`