### PR TITLE
adding RedHat_8.yml to support Centos 8 machines needed for ARM

### DIFF
--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -1,0 +1,27 @@
+---
+sshd_packages:
+  - openssh
+  - openssh-server
+sshd_sftp_server: /usr/libexec/openssh/sftp-server
+sshd_defaults:
+  HostKey:
+    - /etc/ssh/ssh_host_rsa_key
+    - /etc/ssh/ssh_host_ecdsa_key
+    - /etc/ssh/ssh_host_ed25519_key
+  SyslogFacility: AUTHPRIV
+  AuthorizedKeysFile: .ssh/authorized_keys
+  PasswordAuthentication: yes
+  ChallengeResponseAuthentication: no
+  GSSAPIAuthentication: yes
+  GSSAPICleanupCredentials: no
+  # Note that UsePAM: no is not supported under RHEL/CentOS. See
+  # https://github.com/willshersystems/ansible-sshd/pull/51#issuecomment-287333218
+  UsePAM: yes
+  X11Forwarding: yes
+  AcceptEnv:
+    - LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+    - LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+    - LC_IDENTIFICATION LC_ALL LANGUAGE
+    - XMODIFIERS
+  Subsystem: "sftp {{ sshd_sftp_server }}"
+sshd_os_supported: yes


### PR DESCRIPTION
yml file adapted from main repo https://github.com/willshersystems/ansible-sshd/blob/master/vars/RedHat_8.yml and adapted to fit Yugabyte fork's syntax. 

Allows universe creation to succeed from Platform on Centos 8 machines from AWS public marketplace. 