### PR TITLE
changing state tag to present to be compatible with Ubuntu apt-get

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
   action: >
     {{ ansible_pkg_mgr }}
     name="{{ item }}"
-    state=installed
+    state=present
   with_items: "{{ sshd_packages }}"
   tags:
     - sshd


### PR DESCRIPTION
on Ubuntu 18.04 ansible-sshd fails with error 'value of state must be one of: absent, build-dep, fixed, latest, present, got: installed' when trying to install openssh-server. 

changing state to present plays well with Ubuntu and doesn't break existing flows. 