### PR TITLE
[Platform] Only register custom ssh port if it is not the default port

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,6 +36,7 @@
   # `ansible_selinux` can be either a boolean or a dictionary:
   # https://github.com/ansible/ansible/issues/18692
   when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
+        and sshd.Port != '22'
 
 - name: Run directory
   file:


### PR DESCRIPTION
This change should make it possible to avoid installing `policycoreutils-python` on Centos 7 when we are not using a custom SSH port. This can help in airgapped scenarios. This is necessary for [D16465](https://phabricator.dev.yugabyte.com/D16465).